### PR TITLE
docs: add information for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ GRUB_THEME="/usr/share/grub/themes/catppuccin-mocha-grub-theme/theme.txt"
 ```shell
 sudo grub-mkconfig -o /boot/grub/grub.cfg
 ```
+For Fedora:
+```shell
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+```
 
 ## 🙋 FAQ
 


### PR DESCRIPTION
Fedora's grub utils works a bit different from other distros. `grub-mkconfig` is instead named as `grub2-mkconfig`. The same pattern applies to `/boot/grub`, now being `/boot/grub2`. The rest, as far as I'm aware, it is fine