### PR TITLE
refactor: increase boot menu width

### DIFF
--- a/ventoy/src/frappe/catppuccin-frappe/theme.txt
+++ b/ventoy/src/frappe/catppuccin-frappe/theme.txt
@@ -29,9 +29,9 @@ terminal-border: "0"
 
 # Show the boot menu
 + boot_menu {
-  left = 50%-240
+  left = 50%-390
   top = 30%
-  width = 480
+  width = 780
   height = 30%
   item_font = "Unifont Regular 16"
   item_color = "#C6D0F5"

--- a/ventoy/src/latte/catppuccin-latte/theme.txt
+++ b/ventoy/src/latte/catppuccin-latte/theme.txt
@@ -29,9 +29,9 @@ terminal-border: "0"
 
 # Show the boot menu
 + boot_menu {
-  left = 50%-240
+  left = 50%-390
   top = 30%
-  width = 480
+  width = 780
   height = 30%
   item_font = "Unifont Regular 16"
   item_color = "#4C4F69"

--- a/ventoy/src/macchiato/catppuccin-macchiato/theme.txt
+++ b/ventoy/src/macchiato/catppuccin-macchiato/theme.txt
@@ -29,9 +29,9 @@ terminal-border: "0"
 
 # Show the boot menu
 + boot_menu {
-  left = 50%-240
+  left = 50%-390
   top = 30%
-  width = 480
+  width = 780
   height = 30%
   item_font = "Unifont Regular 16"
   item_color = "#CAD3F5"

--- a/ventoy/src/mocha/catppuccin-mocha/theme.txt
+++ b/ventoy/src/mocha/catppuccin-mocha/theme.txt
@@ -29,9 +29,9 @@ terminal-border: "0"
 
 # Show the boot menu
 + boot_menu {
-  left = 50%-240
+  left = 50%-390
   top = 30%
-  width = 480
+  width = 780
   height = 30%
   item_font = "Unifont Regular 16"
   item_color = "#CDD6F4"


### PR DESCRIPTION
I updated the width of the boot menus.

When using btrfs snapshots in GRUB, 
the snapshots names and metadata where cropped.