### PR TITLE
chore: update installation instructions for Fedora/GRUB 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,44 @@
     sudo grub-mkconfig -o /boot/grub/grub.cfg
     ```
 
-    For Fedora:
+### Fedora/GRUB 2
+
+The process for Fedora/GRUB 2 is slightly different than detailed above.
+
+1. Clone this repository locally and enter the cloned folder:
+
+    ```shell
+    git clone https://github.com/catppuccin/grub.git && cd grub
+    ```
+
+2. Copy all or selected theme from `src` folder to
+`/boot/grub2/themes/`. E.g. to copy all themes use:
+
+    ```shell
+    sudo cp -r src/* /boot/grub2/themes/
+    ```
+
+3. Uncomment and edit following line in `/etc/default/grub` to your selected
+   theme:
+
+    ```shell
+    GRUB_THEME="/boot/grub2/themes/catppuccin-<flavor>-grub-theme/theme.txt"
+    ```
+
+3. Edit following line in `/etc/default/grub` to use a graphical terminal that
+   can display images:
+
+    ```shell
+    GRUB_TERMINAL_OUTPUT="gfxterm" # ...should be "console" by default
+    ```
+
+4. Update grub:
 
     ```shell
     sudo grub2-mkconfig -o /boot/grub2/grub.cfg
     ```
+
+5. Reboot your system.
 
 ## 💿 Ventoy Support
 

--- a/README.md
+++ b/README.md
@@ -85,20 +85,18 @@ The process for Fedora/GRUB 2 is slightly different than detailed above.
     GRUB_THEME="/boot/grub2/themes/catppuccin-<flavor>-grub-theme/theme.txt"
     ```
 
-3. Edit following line in `/etc/default/grub` to use a graphical terminal that
+4. Edit following line in `/etc/default/grub` to use a graphical terminal that
    can display images:
 
     ```shell
     GRUB_TERMINAL_OUTPUT="gfxterm" # ...should be "console" by default
     ```
 
-4. Update grub:
+5. Update grub:
 
     ```shell
     sudo grub2-mkconfig -o /boot/grub2/grub.cfg
     ```
-
-5. Reboot your system.
 
 ## 💿 Ventoy Support
 


### PR DESCRIPTION
I've recently installed this on Fedora and the steps I had to take to get this theme working are different to those that are currently documented. As such, I've updated the `README.md` to reflect the steps I took to get this working.

Though I did this on Fedora 40, I expect that the steps are identical for GRUB 2 regardless. I'm open to amendments if necessary.